### PR TITLE
Sublime Text 3 Support

### DIFF
--- a/Edit.py
+++ b/Edit.py
@@ -1,0 +1,77 @@
+# edit.py
+# buffer editing for both ST2 and ST3 that "just works"
+# See https://github.com/SublimeText/Tag/commit/f09952751b6a2b131d83927593b6e788afb48a9e
+
+import sublime
+import sublime_plugin
+from collections import defaultdict
+
+try:
+    sublime.edit_storage
+except AttributeError:
+    sublime.edit_storage = {}
+
+class EditStep:
+    def __init__(self, cmd, *args):
+        self.cmd = cmd
+        self.args = args
+
+    def run(self, view, edit):
+        if self.cmd == 'callback':
+            return self.args[0](view, edit)
+
+        funcs = {
+            'insert': view.insert,
+            'erase': view.erase,
+            'replace': view.replace,
+        }
+        func = funcs.get(self.cmd)
+        if func:
+            func(edit, *self.args)
+
+
+class Edit:
+    defer = defaultdict(dict)
+
+    def __init__(self, view):
+        self.view = view
+        self.steps = []
+
+    def step(self, cmd, *args):
+        step = EditStep(cmd, *args)
+        self.steps.append(step)
+
+    def insert(self, point, string):
+        self.step('insert', point, string)
+
+    def erase(self, region):
+        self.step('erase', region)
+
+    def replace(self, region, string):
+        self.step('replace', region, string)
+
+    def callback(self, func):
+        self.step('callback', func)
+
+    def run(self, view, edit):
+        for step in self.steps:
+            step.run(view, edit)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        view = self.view
+        if sublime.version().startswith('2'):
+            edit = view.begin_edit()
+            self.run(edit)
+            view.end_edit(edit)
+        else:
+            key = str(hash(tuple(self.steps)))
+            sublime.edit_storage[key] = self.run
+            view.run_command('apply_edit', {'key': key})
+
+
+class apply_edit(sublime_plugin.TextCommand):
+    def run(self, edit, key):
+        sublime.edit_storage.pop(key)(self.view, edit)

--- a/RubyExtractMethod.py
+++ b/RubyExtractMethod.py
@@ -1,11 +1,11 @@
-# Ruby Extract Method - Sublime Text 2 Plugin
+# Ruby Extract Method - Sublime Text 2 & 3 Plugin
 # Created by Pasha Muravyev (pashamur)
 # https://github.com/pashamur/ruby-extract-method
 
 import sublime
 import sublime_plugin
 import textwrap
-import string
+from .Edit import Edit as Edit
 
 
 class RubyExtractMethodCommand(sublime_plugin.TextCommand):
@@ -31,10 +31,11 @@ class RubyExtractMethodCommand(sublime_plugin.TextCommand):
         return self.view.substr(region)
 
     def replace_region_content_with_method_name(self, region, method_name):
-        if self.region_ends_with_newline(region):
-            self.view.replace(self.edit, region, method_name+"\n")
-        else:
-            self.view.replace(self.edit, region, method_name)
+        with Edit(self.view) as edit:
+            if self.region_ends_with_newline(region):
+                edit.replace(region, method_name+"\n")
+            else:
+                edit.replace(region, method_name)
         self.view.window().run_command('reindent')
 
     def region_ends_with_newline(self, region):
@@ -48,7 +49,7 @@ class RubyExtractMethodCommand(sublime_plugin.TextCommand):
 
     def indent_text(self, text):
         indentation = self.get_indentation_string()
-        dedented_text = textwrap.dedent(string.expandtabs(text, self.tab_size()))
+        dedented_text = textwrap.dedent(text)
         indented_text = "\n".join(indentation + line for line in dedented_text.splitlines())
         return indented_text
 


### PR DESCRIPTION
Great plugin but unfortunately it doesn't work with Sublime Text 3:

``` python
self.view.replace(self.edit, region, method_name)
File "/Applications/Sublime Text.app/Contents/MacOS/sublime.py", line 588, in replace
raise ValueError("Edit objects may not be used after the TextCommand's run method has returned")
ValueError: Edit objects may not be used after the TextCommand's run method has returned
```

I came up with this solution borrowed from https://github.com/SublimeText/Tag/issues/45 and it works fine for me on ST3.

Changes:
- Use Edit.py for text replacement
- Remove `string.expandtabs` because of `AttributeError: 'module' object has no attribute 'expandtabs'` under ST3.
